### PR TITLE
Added cluster storage to NodeGroupType

### DIFF
--- a/jelapi/classes/nodegroup.py
+++ b/jelapi/classes/nodegroup.py
@@ -35,6 +35,7 @@ class JelasticNodeGroup(_JelasticObject):
         SQL_DATABASE = "sqldb"
         NOSQL_DATABASE = "nosqldb"
         STORAGE_CONTAINER = "storage"
+        CLUSTER_STORAGE = "storage3"
 
     nodeGroupType = _JelAttr(read_only=True)
     envName = _JelAttrStr(read_only=True)


### PR DESCRIPTION
Jelapi has an option to have cluster storage, with the nodeGroupTyp _storage3_ if this one is used, jelapi will crash as it doesn't know this type.

By adding this type to the api jelapi won't crash anymore